### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,7 @@
         "open": "~0.0.4",
         "expect.js": "~0.2.0"
     },
-    "license": {
-        "type": "MIT",
-        "url": "http://www.opensource.org/licenses/mit-license.php"
-    },
+    "license": "MIT",
     "scripts": {
         "test": "mocha ./spec/*.js",
         "build": "gulp",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)
